### PR TITLE
Make escape pod vectors work

### DIFF
--- a/internal/voice/process.go
+++ b/internal/voice/process.go
@@ -216,12 +216,23 @@ procloop:
 						Timezone:   hw.Timezone,
 					})
 				} else {
-					// Replaces Intent with hybrid that can respond to KG directly if necessary
-					option = stream.WithIntentGraphOptions(chipper.IntentGraphOpts{
-						StreamOpts: chipperOpts,
-						Handler:    p.opts.handler,
-						Mode:       serverMode,
-					}, mode)
+					// TODO: Figure a way to find out if it is in ESCAPE_POD mode
+					escape_pod_mode := false
+					if escape_pod_mode {
+						// Replaces Intent with hybrid that can respond to KG directly if necessary
+						option = stream.WithIntentOptions(chipper.IntentOpts{
+							StreamOpts: chipperOpts,
+							Handler:    p.opts.handler,
+							Mode:       serverMode,
+						}, mode)
+					} else {
+						// Replaces Intent with hybrid that can respond to KG directly if necessary
+						option = stream.WithIntentGraphOptions(chipper.IntentGraphOpts{
+							StreamOpts: chipperOpts,
+							Handler:    p.opts.handler,
+							Mode:       serverMode,
+						}, mode)
+					}
 				}
 				logVerbose("Got hotword event", serverMode)
 				newReceiver := *cloudChans

--- a/internal/voice/process.go
+++ b/internal/voice/process.go
@@ -218,16 +218,16 @@ procloop:
 				} else {
 					// TODO: Figure a way to find out if it is in ESCAPE_POD mode
 					escape_pod_mode := false
-					if escape_pod_mode {
+					if !escape_pod_mode {
 						// Replaces Intent with hybrid that can respond to KG directly if necessary
-						option = stream.WithIntentOptions(chipper.IntentOpts{
+						option = stream.WithIntentGraphOptions(chipper.IntentGraphOpts{
 							StreamOpts: chipperOpts,
 							Handler:    p.opts.handler,
 							Mode:       serverMode,
 						}, mode)
 					} else {
 						// Replaces Intent with hybrid that can respond to KG directly if necessary
-						option = stream.WithIntentGraphOptions(chipper.IntentGraphOpts{
+						option = stream.WithIntentOptions(chipper.IntentOpts{
 							StreamOpts: chipperOpts,
 							Handler:    p.opts.handler,
 							Mode:       serverMode,

--- a/internal/voice/stream/connect.go
+++ b/internal/voice/stream/connect.go
@@ -142,6 +142,8 @@ func (strm *Streamer) openChipperStream(ctx context.Context, creds credentials.P
 		stream, err = conn.NewIntentGraphStream(ctx, *strm.opts.intentGraphOpts)
 	case strm.opts.kgOpts != nil:
 		stream, err = conn.NewKGStream(ctx, *strm.opts.kgOpts)
+	case strm.opts.intentOpts != nil:
+		stream, err = conn.NewIntentStream(ctx, *strm.opts.intentOpts)
 	default:
 		err = errors.New("fatal error: all stream option types are nil")
 	}

--- a/internal/voice/stream/context.go
+++ b/internal/voice/stream/context.go
@@ -116,6 +116,8 @@ func (strm *Streamer) responseRoutine() {
 			sendKGResponse(r, strm.receiver, false)
 		case *chipper.ConnectionCheckResponse:
 			sendConnectionCheckResponse(r, strm.receiver, strm.opts.checkOpts)
+		case *chipper.IntentResult:
+			sendIntentResponse(r, strm.receiver)
 		default:
 			log.Println("Unexpected response type:", fmt.Sprintf("%T", resp))
 		}


### PR DESCRIPTION
TODO: Needs a consistent way of figuring out if it is in escape pod mode.

NOTE: Escape pod vectors are breaking because their servers will not have the updated intentgraph endpoint. Therefore, we need to ensure that the endpoints are not hit.