### PR TITLE
Feat/vec 35 allow vector app to work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,11 @@ vic-gateway: go_deps
 	--user $(UID):$(GID) \
 	armbuilder \
 	upx build/vic-gateway
+
+upload-on-vector:
+	@ssh root@$(ROBOT_IP) "mount -o remount,rw /"
+	@ssh root@$(ROBOT_IP) "systemctl stop vic-cloud"
+	@ssh root@$(ROBOT_IP) "systemctl stop vic-gateway"
+	@scp ./build/vic-cloud root@$(ROBOT_IP):/anki/bin/vic-cloud 
+	@scp ./build/vic-gateway root@$(ROBOT_IP):/anki/bin/vic-gateway 
+	@ssh root@$(ROBOT_IP) "systemctl daemon-reload"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ To build vic-gateway, run...
 ```
 # make vic-gateway
 ```
+## Development
+If you have vector with ssh enabled you can you use the following to easily upload the
+generated binaries.
+
+```
+# make upload-on-vector 
+```
+
+The make command assumes that you have the robot ip saved under the ROBOT_IP, which is 
+a comman practise while developing on vector robots. If you dont have that setup you can 
+use the following.
+
+```
+# make upload-on-vector ROBOT_IP=192.168.65.97
+```
 
 ## Example Customization
 

--- a/internal/voice/stream/connect.go
+++ b/internal/voice/stream/connect.go
@@ -59,7 +59,7 @@ func (strm *Streamer) newChipperConn(ctx context.Context) (Conn, *CloudError) {
 			},
 		}
 
-		otaURL = "https://" + config.Env.Check + suffix
+		otaURL = "http://" + config.Env.Check + suffix
 		req, err = http.NewRequest("HEAD", otaURL, nil)
 		if err != nil {
 			log.Println("Error creating CDN server https head request:", err)

--- a/internal/voice/stream/connect.go
+++ b/internal/voice/stream/connect.go
@@ -59,7 +59,7 @@ func (strm *Streamer) newChipperConn(ctx context.Context) (Conn, *CloudError) {
 			},
 		}
 
-		otaURL = "http://" + config.Env.Check + suffix
+		otaURL = "https://" + config.Env.Check + suffix
 		req, err = http.NewRequest("HEAD", otaURL, nil)
 		if err != nil {
 			log.Println("Error creating CDN server https head request:", err)


### PR DESCRIPTION
This pull request fixes the broken link to do a chipper connection test. Allowing the Vector app to work with Vectors on  escape-pod stack